### PR TITLE
Add KLD resampling to CGR particle filter.

### DIFF
--- a/config/localization_parameters.cfg
+++ b/config/localization_parameters.cfg
@@ -1,19 +1,28 @@
 
 initialConditions = {
   mapName = "GHC7";
-  
+
   loc = vec2(-8.708, 42.837);
   angle = deg2rad(-165.0);
-  
+
   locUncertainty = 0.1;
   angleUncertainty = deg2rad(4.0);
+};
+
+kldParams = {
+  minParticles = 5;
+  maxParticles = 20000;
+  bin_size = 0.1;
+  angular_bin_size = deg2rad(4.0);
+  error = 0.2;
+  z_score = 2.5;
 };
 
 motionParams = {
   Alpha1 = 0.1;
   Alpha2 = deg2rad(5.0);
   Alpha3 = 0.1;
-  
+
   kernelSize = 5.0;
 };
 
@@ -31,24 +40,24 @@ lidarParams = {
   maxAngle = 0.5*deg2rad(360.0/1024.0)*768;
   maxRange = 4.0;
   minRange = 0.025;
-  
+
   -- Default values, up-to-date values will be read from tf listener
   laserLoc = vec2(0.145,0.0);
   xRot = 0;
   yRot = 0;
   zRot = 0;
-  
+
   correlationFactor = 1.0/80000.0;
   logShortHitProb = -sq(1.5/0.03);
   lidarStdDev = sq(0.03);
   logObstacleProb = -sq(0.8/0.03);
   logOutOfRangeProb = -sq(4.0/0.03);
   kernelSize = 5.0;
-  
+
   minPoints = 10;
   numSteps = refineParams.numSteps;
   correspondenceMargin = 0.1;
-  
+
   etaAngle = 4*0.05;
   etaLoc = 4*0.1;
   maxAngleGradient = deg2rad(10.0);
@@ -71,10 +80,10 @@ pointCloudParams = {
   minRange = 0.1;
   maxRange = 10.0;
 
-  attractorRange = 0.75; 
+  attractorRange = 0.75;
   minCosAngleError  = cos(deg2rad(30.0));
-  
-  
+
+
   correlationFactor = 1.0/80000.0;
   logShortHitProb = -sq(1.5/0.2);
   stdDev = sq(0.2);

--- a/src/cgr/localization_main.cpp
+++ b/src/cgr/localization_main.cpp
@@ -59,8 +59,6 @@ vector2f initialLoc;
 float initialAngle;
 float locUncertainty, angleUncertainty;
 
-int minParticles, maxParticles;
-
 VectorLocalization2D *localization;
 
 using namespace ros;

--- a/src/cgr/localization_main.cpp
+++ b/src/cgr/localization_main.cpp
@@ -52,12 +52,14 @@ using namespace std;
 bool run = true;
 bool usePointCloud = false;
 bool noLidar = false;
-int numParticles = 20;
+int numParticles = 100;
 int debugLevel = -1;
 
 vector2f initialLoc;
 float initialAngle;
 float locUncertainty, angleUncertainty;
+
+int minParticles, maxParticles;
 
 VectorLocalization2D *localization;
 
@@ -100,7 +102,7 @@ void depthCallback(const sensor_msgs::Image& msg);
 void publishLocation(bool limitRate=true);
 
 bool localizationCallback(LocalizationInterfaceSrv::Request& req, LocalizationInterfaceSrv::Response& res)
-{  
+{
   vector2f loc(req.loc_x, req.loc_y);
   if(debugLevel>0) printf("Setting location: %f %f %f\u00b0 on %s\n",V2COMP(loc),DEG(req.orientation),req.map.c_str());
   localization->setLocation(loc, req.orientation,req.map.c_str(),0.01,RAD(1.0));
@@ -120,14 +122,14 @@ void ClearGUI()
   guiMsg.circles_x.clear();
   guiMsg.circles_y.clear();
   guiMsg.circles_col.clear();
-  
+
   guiMsg.windowSize = 1.0;
 }
 
 void drawPointCloud()
 {
   //printf("publishing %d points\n",(int) pointCloud.size());
-  
+
   for(int i=0; i<(int) pointCloud.size(); i++){
     guiMsg.points_x.push_back(pointCloud[i].x);
     guiMsg.points_y.push_back(pointCloud[i].y);
@@ -148,9 +150,9 @@ void publishLocation(bool limitRate)
   msg.y = curLoc.y;
   msg.angle = curAngle;
   msg.map = string(localization->getCurrentMapName());
-  
+
   localization->getUncertainty(msg.angleUncertainty, msg.locationUncertainty);
-  
+
   VectorLocalization2D::EvalValues laserEval, pointCloudEval;
   localization->getEvalValues(laserEval,pointCloudEval);
   msg.laserNumCorrespondences = laserEval.numCorrespondences;
@@ -160,7 +162,7 @@ void publishLocation(bool limitRate)
   msg.laserRunTime = laserEval.runTime;
   msg.lastLaserRunTime = laserEval.lastRunTime;
   msg.laserMeanSqError = laserEval.meanSqError;
-  
+
   msg.pointCloudNumCorrespondences = pointCloudEval.numCorrespondences;
   msg.pointCloudNumObservedPoints = pointCloudEval.numObservedPoints;
   msg.pointCloudStage0Weights = pointCloudEval.stage0Weights;
@@ -168,13 +170,13 @@ void publishLocation(bool limitRate)
   msg.pointCloudRunTime = pointCloudEval.runTime;
   msg.lastPointCloudRunTime = pointCloudEval.lastRunTime;
   msg.pointCloudMeanSqError = pointCloudEval.meanSqError;
-  
+
   localizationPublisher.publish(msg);
-  
+
   //Publish particles
   vector<Particle2D> particles;
   localization->getParticles(particles);
-  particlesMsg.poses.resize(particles.size()); 
+  particlesMsg.poses.resize(particles.size());
   geometry_msgs::Pose particle;
   for(unsigned int i=0; i<particles.size(); i++){
     particle.position.x = particles[i].loc.x;
@@ -187,24 +189,24 @@ void publishLocation(bool limitRate)
     particlesMsg.poses[i] = particle;
   }
   particlesPublisher.publish(particlesMsg);
-  
+
   //Publish map to base_footprint tf
   try{
     tf::StampedTransform odomToBaseTf;
     transformListener->lookupTransform("odom","base_footprint",ros::Time(0), odomToBaseTf);
-    
+
     vector2f map_base_trans = curLoc;
     float map_base_rot = curAngle;
-    
+
     vector2f odom_base_trans(odomToBaseTf.getOrigin().x(), odomToBaseTf.getOrigin().y());
     float odom_base_rot = 2.0*atan2(odomToBaseTf.getRotation().z(), odomToBaseTf.getRotation().w());
-    
+
     vector2f base_odom_trans = -odom_base_trans.rotate(-odom_base_rot);
     float base_odom_rot = -odom_base_rot;
-    
+
     vector2f map_odom_trans = map_base_trans + base_odom_trans.rotate(map_base_rot);
     float map_odom_rot = angle_mod(map_base_rot + base_odom_rot);
-    
+
     tf::Transform mapToOdomTf;
     mapToOdomTf.setOrigin(tf::Vector3(V2COMP(map_odom_trans), 0.0));
     mapToOdomTf.setRotation(tf::Quaternion(tf::Vector3(0,0,1),map_odom_rot));
@@ -216,7 +218,7 @@ void publishLocation(bool limitRate)
 }
 
 void publishGUI()
-{ 
+{
   static double tLast = 0;
   static double publishInterval = 0.016;
   if(debugLevel<0 || GetTimeSec()-tLast<publishInterval)
@@ -236,20 +238,20 @@ void LoadParameters()
 {
   WatchFiles watch_files;
   ConfigReader config(ros::package::getPath("cgr_localization").append("/").c_str());
-  
+
   config.init(watch_files);
-  
+
   config.addFile("config/localization_parameters.cfg");
   config.addFile("config/kinect_parameters.cfg");
-  
+
   if(!config.readFiles()){
     printf("Failed to read config\n");
     exit(1);
   }
-  
+
   {
     ConfigReader::SubTree c(config,"KinectParameters");
-    
+
     unsigned int maxDepthVal;
     bool error = false;
     error = error || !c.getReal("f",kinectDepthCam.f);
@@ -258,8 +260,8 @@ void LoadParameters()
     error = error || !c.getInt("width",kinectDepthCam.width);
     error = error || !c.getInt("height",kinectDepthCam.height);
     error = error || !c.getUInt("maxDepthVal",maxDepthVal);
-    kinectDepthCam.maxDepthVal = maxDepthVal;    
-    
+    kinectDepthCam.maxDepthVal = maxDepthVal;
+
     vector3f kinectLoc;
     float xRot, yRot, zRot;
     error = error || !c.getVec3f("loc",kinectLoc);
@@ -267,16 +269,16 @@ void LoadParameters()
     error = error || !c.getReal("yRot",yRot);
     error = error || !c.getReal("zRot",zRot);
     kinectToRobotTransform.xyzRotationAndTransformation(xRot,yRot,zRot,kinectLoc);
-    
+
     if(error){
       printf("Error Loading Kinect Parameters!\n");
       exit(2);
     }
-  } 
-  
+  }
+
   {
     ConfigReader::SubTree c(config,"PlaneFilteringParameters");
-    
+
     bool error = false;
     error = error || !c.getUInt("maxPoints",filterParams.maxPoints);
     error = error || !c.getUInt("numSamples",filterParams.numSamples);
@@ -288,16 +290,16 @@ void LoadParameters()
     error = error || !c.getReal("WorldPlaneSize",filterParams.WorldPlaneSize);
     error = error || !c.getUInt("numRetries",filterParams.numRetries);
     filterParams.runPolygonization = false;
-    
+
     if(error){
       printf("Error Loading Plane Filtering Parameters!\n");
       exit(2);
     }
-  } 
-  
+  }
+
   {
     ConfigReader::SubTree c(config,"initialConditions");
-    
+
     bool error = false;
     curMapName = string(c.getStr("mapName"));
     error = error || curMapName.length()==0;
@@ -305,39 +307,52 @@ void LoadParameters()
     error = error || !c.getReal("angle", initialAngle);
     error = error || !c.getReal("locUncertainty", locUncertainty);
     error = error || !c.getReal("angleUncertainty", angleUncertainty);
-    
+
     if(error){
       printf("Error Loading Initial Conditions!\n");
       exit(2);
     }
   }
-  
+
+  {
+    ConfigReader::SubTree c(config,"kldParams");
+
+    bool error = false;
+    error = error || !c.getInt("minParticles",minParticles);
+    error = error || !c.getInt("maxParticles",maxParticles);
+
+    if (error) {
+      printf("Error Loading KLD Params!\n");
+      exit(2);
+    }
+  }
+
   {
     ConfigReader::SubTree c(config,"motionParams");
-    
+
     bool error = false;
     error = error || !c.getReal("Alpha1", motionParams.Alpha1);
     error = error || !c.getReal("Alpha2", motionParams.Alpha2);
     error = error || !c.getReal("Alpha3", motionParams.Alpha3);
     error = error || !c.getReal("kernelSize", motionParams.kernelSize);
-    
-    
+
+
     if(error){
       printf("Error Loading Predict Parameters!\n");
       exit(2);
     }
   }
-  
+
   {
     ConfigReader::SubTree c(config,"lidarParams");
-    
+
     bool error = false;
     // Laser sensor properties
     error = error || !c.getReal("angleResolution", lidarParams.angleResolution);
     error = error || !c.getInt("numRays", lidarParams.numRays);
     error = error || !c.getReal("maxRange", lidarParams.maxRange);
     error = error || !c.getReal("minRange", lidarParams.minRange);
-    
+
     // Pose of laser sensor on robot
     vector2f laserToBaseTrans;
     float xRot, yRot, zRot;
@@ -349,7 +364,7 @@ void LoadParameters()
     laserToBaseRot = AngleAxisf(xRot, Vector3f::UnitX()) * AngleAxisf(yRot, Vector3f::UnitY()) * AngleAxisf(zRot, Vector3f::UnitZ());
     lidarParams.laserToBaseTrans = Vector2f(V2COMP(laserToBaseTrans));
     lidarParams.laserToBaseRot = laserToBaseRot.block(0,0,2,2);
-    
+
     // Parameters related to observation update
     error = error || !c.getReal("logObstacleProb", lidarParams.logObstacleProb);
     error = error || !c.getReal("logOutOfRangeProb", lidarParams.logOutOfRangeProb);
@@ -358,7 +373,7 @@ void LoadParameters()
     error = error || !c.getReal("lidarStdDev", lidarParams.lidarStdDev);
     error = error || !c.getReal("attractorRange", lidarParams.attractorRange);
     error = error || !c.getReal("kernelSize", lidarParams.kernelSize);
-    
+
     // Parameters related to observation refine
     error = error || !c.getInt("minPoints", lidarParams.minPoints);
     error = error || !c.getInt("numSteps", lidarParams.numSteps);
@@ -369,18 +384,18 @@ void LoadParameters()
     error = error || !c.getReal("minCosAngleError", lidarParams.minCosAngleError);
     error = error || !c.getReal("correspondenceMargin", lidarParams.correspondenceMargin);
     error = error || !c.getReal("minRefineFraction", lidarParams.minRefineFraction);
-    
+
     lidarParams.initialize();
-    
+
     if(error){
       printf("Error Loading Lidar Parameters!\n");
       exit(2);
     }
   }
-  
+
   {
     ConfigReader::SubTree c(config,"pointCloudParams");
-    
+
     bool error = false;
     error = error || !c.getReal("logObstacleProb", pointCloudParams.logObstacleProb);
     error = error || !c.getReal("logShortHitProb", pointCloudParams.logShortHitProb);
@@ -391,7 +406,7 @@ void LoadParameters()
     error = error || !c.getReal("attractorRange", pointCloudParams.attractorRange);
     error = error || !c.getReal("maxRange", pointCloudParams.maxRange);
     error = error || !c.getReal("minRange", pointCloudParams.minRange);
-    
+
     error = error || !c.getReal("attractorRange", pointCloudParams.attractorRange);
     error = error || !c.getReal("etaAngle", pointCloudParams.etaAngle);
     error = error || !c.getReal("etaLoc", pointCloudParams.etaLoc);
@@ -404,62 +419,62 @@ void LoadParameters()
     error = error || !c.getReal("maxRange", pointCloudParams.maxRange);
     error = error || !c.getReal("correspondenceMargin", pointCloudParams.correspondenceMargin);
     error = error || !c.getReal("minRefineFraction", pointCloudParams.minRefineFraction);
-    
+
     if(error){
       printf("Error Loading Point Cloud Parameters!\n");
       exit(2);
     }
   }
-  
+
   planeFilter.setParameters(&kinectDepthCam,filterParams);
 }
 
 void InitModels(){
   lidarParams.laserScan = (float*) malloc(lidarParams.numRays*sizeof(float));
-  
+
   filteredPointCloudMsg.header.seq = 0;
-  filteredPointCloudMsg.header.frame_id = "base_footprint"; 
+  filteredPointCloudMsg.header.frame_id = "base_footprint";
   filteredPointCloudMsg.channels.clear();
-  
+
   return;
 }
 
 void odometryCallback(const nav_msgs::OdometryConstPtr &msg)
-{ 
+{
   static float angle = 0;
   static vector2f loc(0,0);
   static bool initialized=false;
   static double tLast = 0;
-  
+
   if(tLast>msg->header.stamp.toSec())
     initialized = false;
-  
+
   if(!initialized){
     angle = tf::getYaw(msg->pose.pose.orientation);
     loc = vector2f(msg->pose.pose.position.x, msg->pose.pose.position.y);
     initialized = true;
     return;
   }
-  
+
   float newAngle = tf::getYaw(msg->pose.pose.orientation);
   vector2f newLoc(msg->pose.pose.position.x, msg->pose.pose.position.y);
-  
+
   vector2f d = (newLoc-loc).rotate(-angle);
   double dx = d.x;
   double dy = d.y;
   double dtheta = angle_mod(newAngle-angle);
-  
+
   if((sq(dx)+sq(dy))>sq(0.4) || fabs(dtheta)>RAD(40)){
     printf("Odometry out of bounds: x:%7.3f y:%7.3f a:%7.3f\u00b0\n",dx, dy, DEG(dtheta));
     angle = newAngle;
     loc = newLoc;
     return;
   }
-  
+
   if(debugLevel>0) printf("Odometry t:%f x:%7.3f y:%7.3f a:%7.3f\u00b0\n",msg->header.stamp.toSec(), dx, dy, DEG(dtheta));
-  
+
   localization->predict(dx, dy, dtheta, motionParams);
-  
+
   angle = newAngle;
   loc = newLoc;
 }
@@ -470,7 +485,7 @@ void lidarCallback(const sensor_msgs::LaserScan &msg)
   if(debugLevel>0){
     printf("LIDAR n:%d t:%f noLidar:%d\n",(int) msg.ranges.size(), msg.scan_time, noLidar?1:0);
   }
-  
+
   tf::StampedTransform baseLinkToLaser;
   try{
     transformListener->lookupTransform("base_footprint", msg.header.frame_id, ros::Time(0), baseLinkToLaser);
@@ -480,18 +495,18 @@ void lidarCallback(const sensor_msgs::LaserScan &msg)
   }
   tf::Vector3 translationTf = baseLinkToLaser.getOrigin();
   tf::Quaternion rotationTf = baseLinkToLaser.getRotation();
-  
+
   Quaternionf rotQuat3D(rotationTf.w(), rotationTf.x(), rotationTf.y(), rotationTf.z());
   Matrix3f rot3D(rotQuat3D);
   Vector3f trans3D(translationTf.x(), translationTf.y(),translationTf.z());
-  
+
   trans3D = rot3D*trans3D;
   lidarParams.laserToBaseRot = rot3D.topLeftCorner(2,2);
   lidarParams.laserToBaseTrans = trans3D.topLeftCorner(2,1);
-  
-  bool newLaser = lidarParams.minRange != msg.range_min || 
+
+  bool newLaser = lidarParams.minRange != msg.range_min ||
     lidarParams.maxRange != msg.range_max ||
-    lidarParams.minAngle != msg.angle_min || 
+    lidarParams.minAngle != msg.angle_min ||
     lidarParams.maxAngle != msg.angle_max ||
     lidarParams.angleResolution != msg.angle_increment ||
     lidarParams.numRays != int(msg.ranges.size());
@@ -504,16 +519,16 @@ void lidarCallback(const sensor_msgs::LaserScan &msg)
     lidarParams.numRays = int(msg.ranges.size());
     lidarParams.initialize();
   }
-  
+
   if(int(msg.ranges.size()) != lidarParams.numRays){
     TerminalWarning("Incorrect number of Laser Scan rays!");
     printf("received: %d\n",int(msg.ranges.size()));
   }
-  
+
   for(int i=0; i<(int)msg.ranges.size(); i++)
     lidarParams.laserScan[i] = msg.ranges[i];
-  
-  
+
+
   if(!noLidar){
     localization->refineLidar(lidarParams);
     localization->updateLidar(lidarParams, motionParams);
@@ -532,10 +547,10 @@ void depthCallback(const sensor_msgs::Image &msg)
   const uint8_t* ptrSrc = msg.data.data();
   uint16_t depth[640*480];
   memcpy(depth, ptrSrc, 640*480*(sizeof(uint16_t)));
-  
+
   if(!usePointCloud)
     return;
-  
+
   tf::StampedTransform baseLinkToKinect;
   try{
     transformListener->lookupTransform("base_footprint", msg.header.frame_id, ros::Time(0), baseLinkToKinect);
@@ -563,28 +578,28 @@ void depthCallback(const sensor_msgs::Image &msg)
   kinectToRobotTransform.m42 = 0;
   kinectToRobotTransform.m43 = 0;
   kinectToRobotTransform.m44 = 1;
-  
-  //Generate filtered point cloud  
+
+  //Generate filtered point cloud
   vector<vector3f> filteredPointCloud;
   vector<vector3f> pointCloudNormals;
   vector<vector3f> outlierCloud;
   vector<vector2i> pixelLocs;
   vector<PlanePolygon> planePolygons;
-  
+
   planeFilter.GenerateFilteredPointCloud(depth, filteredPointCloud, pixelLocs, pointCloudNormals, outlierCloud, planePolygons);
-  
+
   //Transform from kinect coordinates to robot coordinates
-  
+
   for(unsigned int i=0; i<filteredPointCloud.size(); i++){
     filteredPointCloud[i] = filteredPointCloud[i].transform(kinectToRobotTransform);
     pointCloudNormals[i] = pointCloudNormals[i].transform(kinectToRobotTransform);
   }
-  
+
 
   if(debugLevel>0){
     filteredPointCloudMsg.points.clear();
     filteredPointCloudMsg.header.stamp = ros::Time::now();
-    
+
     vector<geometry_msgs::Point32>* points = &(filteredPointCloudMsg.points);
     geometry_msgs::Point32 p;
     for(int i=0; i<(int)filteredPointCloud.size(); i++){
@@ -595,22 +610,22 @@ void depthCallback(const sensor_msgs::Image &msg)
     }
     filteredPointCloudPublisher.publish(filteredPointCloudMsg);
   }
-  
+
   //Call particle filter
   {
     vector<vector2f> pointCloud2D, pointCloudNormals2D;
-    
+
     for(unsigned int i=0; i<filteredPointCloud.size(); i++){
       if(fabs(pointCloudNormals[i].z)>sin(RAD(30.0)))
         continue;
-      
+
       vector2f curNormal(V2COMP(pointCloudNormals[i]));
       vector2f curPoint(V2COMP(filteredPointCloud[i]));
       curNormal.normalize();
       pointCloudNormals2D.push_back(curNormal);
       pointCloud2D.push_back(curPoint);
     }
-    
+
     localization->refinePointCloud(pointCloud2D, pointCloudNormals2D, pointCloudParams);
     localization->updatePointCloud(pointCloud2D, pointCloudNormals2D, motionParams, pointCloudParams);
     localization->resample(VectorLocalization2D::LowVarianceResampling);
@@ -628,10 +643,10 @@ void initialPoseCallback(const geometry_msgs::PoseWithCovarianceStamped &msg)
 }
 
 int main(int argc, char** argv)
-{ 
+{
   //========================= Load Parameters from config file ======================
   LoadParameters();
-  
+
   //========================== Set up Command line parameters =======================
   static struct poptOption options[] = {
     { "num-particles",    'n', POPT_ARG_INT,     &numParticles,       0, "Number of Particles",   "NUM"},
@@ -644,7 +659,7 @@ int main(int argc, char** argv)
     { "Alpha1-param",     'u', POPT_ARG_DOUBLE,  &motionParams.Alpha1,  0, "Alpha1 parameter",   "NUM"},
     { "Alpha2-param",     'v', POPT_ARG_DOUBLE,  &motionParams.Alpha2,  0, "Alpha2 parameter",   "NUM"},
     { "Alpha3-param",     'w', POPT_ARG_DOUBLE,  &motionParams.Alpha3,  0, "Alpha3 parameter",   "NUM"},
-    
+
     POPT_AUTOHELP
     { NULL, 0, 0, NULL, 0, NULL, NULL }
   };
@@ -653,14 +668,16 @@ int main(int argc, char** argv)
   int c;
   while((c = popt.getNextOpt()) >= 0){
   }
-  
+
   //========================= Welcome screen, Load map & log ========================
   ColourTerminal(TerminalUtils::TERMINAL_COL_WHITE,TerminalUtils::TERMINAL_COL_BLACK,TerminalUtils::TERMINAL_ATTR_BRIGHT);
   printf("\nVector Localization\n\n");
   ResetTerminal();
-  
+
   if(debugLevel>=0){
     printf("NumParticles     : %d\n",numParticles);
+    printf("minParticles     : %d\n",minParticles);
+    printf("maxParticles     : %d\n",maxParticles);
     printf("Alpha1           : %f\n",motionParams.Alpha1);
     printf("Alpha2           : %f\n",motionParams.Alpha2);
     printf("Alpha3           : %f\n",motionParams.Alpha3);
@@ -672,15 +689,15 @@ int main(int argc, char** argv)
   double seed = floor(fmod(GetTimeSec()*1000000.0,1000000.0));
   if(debugLevel>-1) printf("Seeding with %d\n",(unsigned int)seed);
   srand(seed);
-  
+
   //Initialize particle filter, sensor model, motion model, refine model
   string mapsFolder(ros::package::getPath("cgr_localization").append("/maps/"));
   localization = new VectorLocalization2D(mapsFolder.c_str());
   InitModels();
-  
+
   //Initialize particle filter
   localization->initialize(numParticles,curMapName.c_str(),initialLoc,initialAngle,locUncertainty,angleUncertainty);
-  
+
   //Initialize ros for sensor and odometry topics
   InitHandleStop(&run);
   ros::init(argc, argv, "CGR_Localization");
@@ -689,26 +706,26 @@ int main(int argc, char** argv)
   localizationPublisher = n.advertise<LocalizationMsg>("localization",1,true);
   particlesPublisher = n.advertise<geometry_msgs::PoseArray>("particlecloud",1,false);
   Sleep(0.1);
-  
+
   localizationServer = n.advertiseService("localization_interface", &localizationCallback);
-  
+
   //Initialize ros for sensor and odometry topics
   ros::Subscriber odometrySubscriber = n.subscribe("odom", 20, odometryCallback);
   ros::Subscriber lidarSubscriber = n.subscribe("scan", 5, lidarCallback);
   ros::Subscriber kinectSubscriber = n.subscribe("kinect_depth", 1, depthCallback);
   ros::Subscriber initialPoseSubscriber = n.subscribe("initialpose",1,initialPoseCallback);
   transformListener = new tf::TransformListener(ros::Duration(10.0));
-  transformBroadcaster = new tf::TransformBroadcaster();  
-  
+  transformBroadcaster = new tf::TransformBroadcaster();
+
   filteredPointCloudPublisher = n.advertise<sensor_msgs::PointCloud>("Cobot/Kinect/FilteredPointCloud", 1);
-  
+
   while(ros::ok() && run){
     ros::spinOnce();
     publishGUI();
     publishLocation();
     Sleep(0.005);
   }
-  
+
   if(debugLevel>=0) printf("closing.\n");
   return 0;
 }

--- a/src/cgr/localization_main.cpp
+++ b/src/cgr/localization_main.cpp
@@ -643,7 +643,7 @@ void initialPoseCallback(const geometry_msgs::PoseWithCovarianceStamped &msg)
   vector2f loc(V2COMP(msg.pose.pose.position));
   printf("Initializing CGR localization at %.3f,%.3f, %.2f\u00b0\n",V2COMP(loc), DEG(angle));
   //localization->initialize(numParticles,curMapName.c_str(), loc, angle,sqrt(msg.pose.covariance[0]),sqrt(msg.pose.covariance[35]));
-  localization->initialize(numParticles,curMapName.c_str(), loc, angle, locUncertainty,RAD(10.0));
+  localization->initialize(numParticles,curMapName.c_str(), loc, angle,0.01,RAD(1.0));
 }
 
 int main(int argc, char** argv)

--- a/src/cgr/vectorparticlefilter.cpp
+++ b/src/cgr/vectorparticlefilter.cpp
@@ -1063,7 +1063,6 @@ void VectorLocalization2D::lowVarianceResample()
     if(i<numParticles)
       refinedImportanceWeights += particlesRefined[i].weight;
     else {
-      printf("this happened?\n");
       unrefinedImportanceWeights += particlesRefined[i].weight;
     }
   }
@@ -1112,6 +1111,7 @@ void VectorLocalization2D::lowVarianceResample()
 
 void VectorLocalization2D::kldResample(KLDParams kldParams)
 {
+  const bool debug = false;
   vector<Particle2D> newParticles;
   float totalWeight = 0.0;
   float newWeight = 1.0/float(numParticles);
@@ -1126,7 +1126,6 @@ void VectorLocalization2D::kldResample(KLDParams kldParams)
     if(i<numParticles)
       refinedImportanceWeights += particlesRefined[i].weight;
     else {
-      printf("this happened?\n");
       unrefinedImportanceWeights += particlesRefined[i].weight;
     }
   }
@@ -1203,7 +1202,8 @@ void VectorLocalization2D::kldResample(KLDParams kldParams)
       numParticles < kldParams.maxParticles;
   } while (continue_condition);
 
-  printf("num_bins: %d, numParticles: %d\n", num_filled_bins, numParticles);
+  if (debug)
+    printf("num_bins: %d, numParticles: %d\n", num_filled_bins, numParticles);
 
   particles = newParticles;
 }

--- a/src/cgr/vectorparticlefilter.cpp
+++ b/src/cgr/vectorparticlefilter.cpp
@@ -107,7 +107,7 @@ void VectorLocalization2D::setLocation(vector2f loc, float angle, const char* ma
     char buf[4096];
     snprintf(buf, 4095, "Unknown map: \"%s\"",map);
     TerminalWarning(buf);
-  }  
+  }
 }
 
 void VectorLocalization2D::setLocation(vector2f loc, float angle, float locationUncertainty, float angleUncertainty)
@@ -140,7 +140,7 @@ void VectorLocalization2D::setMap(const char* map)
 void VectorLocalization2D::initialize(int _numParticles, const char* mapName, vector2f loc, float angle, float locationUncertainty, float angleUncertainty)
 {
   static const bool debug = false;
-  
+
   currentMap = &maps[0];
   bool found = false;
   for(unsigned int i=0; i<maps.size(); i++){
@@ -154,7 +154,7 @@ void VectorLocalization2D::initialize(int _numParticles, const char* mapName, ve
     snprintf(buf,2047,"Map %s not found in Atlas! Reverting to map %s.",mapName,maps[0].mapName.c_str());
     TerminalWarning(buf);
   }
-  
+
   numParticles = _numParticles;
   particles.resize(numParticles);
   stage0Weights.resize(numParticles);
@@ -171,21 +171,21 @@ void VectorLocalization2D::initialize(int _numParticles, const char* mapName, ve
     }
     particles[i] = createParticle(currentMap, loc, angle, locationUncertainty, angleUncertainty);
   }
-  
+
   computeLocation(loc, angle);
-  
+
   laserEval.numCorrespondences = 0;
   laserEval.numObservedPoints = 0;
   laserEval.runTime = 0;
   laserEval.stage0Weights = 0;
   laserEval.stageRWeights = 0;
-  
+
   pointCloudEval.numCorrespondences = 0;
   pointCloudEval.numObservedPoints = 0;
   pointCloudEval.runTime = 0;
   pointCloudEval.stage0Weights = 0;
   pointCloudEval.stageRWeights = 0;
-  
+
   if(debug) printf("\nDone.\n");
 }
 
@@ -223,7 +223,7 @@ float VectorLocalization2D::observationWeightPointCloud(vector2f loc, float angl
   float sqMaxRange = sq(maxRange);
   float stdDev = pointCloudParams.stdDev;
   float curAngle;
-  
+
   vector<line2f> lines;
 
   float a0 = angle-0.5*pointCloudParams.fieldOfView;
@@ -234,15 +234,15 @@ float VectorLocalization2D::observationWeightPointCloud(vector2f loc, float angl
     lineCorrespondences = currentMap->getRayToLineCorrespondences(loc, angle, a0, a1, pointCloud, minRange, maxRange);
     lines = currentMap->lines;
   }
-  
+
   float logTotalWeight = 0.0;
-  
-  Matrix2f rotMat1; 
+
+  Matrix2f rotMat1;
   rotMat1 = Rotation2Df(angle);
-  
+
   int numCorrespondences = 0;
   Vector2f heading, scanPoint, lineNorm, curPoint, attraction, locE(V2COMP(loc)), rotatedNormal;
-  
+
   for(int i=0; i<pointCloud.size(); i++){
     curPoint = rotMat1*Vector2f(V2COMP(pointCloud[i])) + locE;
     attraction = Vector2f(0.0,0.0);
@@ -286,7 +286,7 @@ float VectorLocalization2D::observationWeightLidar(vector2f loc, float angle, co
   float logOutOfRangeProb = lidarParams.logOutOfRangeProb;
   float logObstacleProb = lidarParams.logObstacleProb;
   float logShortHitProb = lidarParams.logShortHitProb;
-  
+
   vector2f laserLoc = loc + vector2f(lidarParams.laserToBaseTrans.x(),lidarParams.laserToBaseTrans.y()).rotate(angle);
   vector<line2f> lines;
   if(UseAnalyticRender){
@@ -294,18 +294,18 @@ float VectorLocalization2D::observationWeightLidar(vector2f loc, float angle, co
   }else{
     lineCorrespondences = currentMap->getRayToLineCorrespondences(laserLoc, angle, lidarParams.angleResolution, numRays, 0.0, maxRange, false, NULL);
   }
-  
+
   float *scanRays = lidarParams.laserScan;
   float curAngle;
   Vector2f attraction;
   float midScan = float(numRays)/2.0;
-  
+
   Matrix2f robotAngle;
   robotAngle = Rotation2Df(angle);
   Vector2f heading, scanPoint, laserLocE(V2COMP(laserLoc));
-  
+
   float logTotalWeight = 0.0;
-  
+
   Vector2f scanPoint2, scanDir, lineDir;
   Matrix2f robotAngle2;
   robotAngle2 = Rotation2Df(angle+lidarParams.angleResolution);
@@ -314,7 +314,7 @@ float VectorLocalization2D::observationWeightLidar(vector2f loc, float angle, co
       logTotalWeight += logObstacleProb*lidarParams.correlationFactor;
       continue;
     }
-    
+
     if(lineCorrespondences[i]>=0){
       scanPoint = laserLocE + robotAngle*laserPoints[i];
       scanPoint2 = laserLocE + robotAngle2*laserPoints[i+1];
@@ -333,7 +333,7 @@ float VectorLocalization2D::observationWeightLidar(vector2f loc, float angle, co
       }else{
         logTotalWeight += logObstacleProb*lidarParams.correlationFactor;
       }
-      
+
     }else if(scanRays[i]<maxRange){
       logTotalWeight += logObstacleProb*lidarParams.correlationFactor;
     }else{
@@ -349,20 +349,20 @@ float VectorLocalization2D::observationWeightLidar(vector2f loc, float angle, co
 void VectorLocalization2D::computeParticleWeights(vector2f deltaLoc, float deltaAngle, vector2f minLocStdDev, float minAngleStdDev, const MotionModelParams &motionParams)
 {
   static const bool debug = false;
-  
+
   int N = particles.size();
   vector<vector2f> locMean(2*N);
   vector<vector2f> locStdDev(2*N);
   vector<float> angleMean(2*N);
   vector<float> angleStdDev(2*N);
-  
+
   currentLocStdDev.x = max(minLocStdDev.x,currentLocStdDev.x);
   currentLocStdDev.y = max(minLocStdDev.y,currentLocStdDev.y);
   currentAngleStdDev = max(minAngleStdDev,currentAngleStdDev);
-  
+
   // Compute kernel supports for motion model weights
   float deltaTranslation = deltaLoc.length();
-  
+
   for(int i=0; i<N; i++){
     angleMean[i] = particles[i].angle;
     angleStdDev[i] = 1.0/sq( max( float(fabs(deltaAngle))*motionParams.Alpha1 + deltaTranslation*motionParams.Alpha2 , currentAngleStdDev) );
@@ -381,20 +381,20 @@ void VectorLocalization2D::computeParticleWeights(vector2f deltaLoc, float delta
       p2.weight += exp(-sq(p2.loc.x - locMean[j].x)*locStdDev[j].x -sq(p2.loc.y - locMean[j].y)*locStdDev[j].y  -sq(angle_diff(p2.angle , angleMean[j]))*angleStdDev[j] );
     }
   }
-  
+
   if(debug){
     printf("Motion model weights:\n");
     for(int i=0; i<N; i++){
       printf("%2d unrefined:%20.16f, %20.16f refined:%20.16f, %20.16f\n",i, particles[i].weight,stage0Weights[i], particlesRefined[i].weight,stageRWeights[i]);
     }
   }
-  
+
   // Apply observation function weights
   for(int i=0; i<N; i++){
     particles[i].weight *= stage0Weights[i];
     particlesRefined[i].weight *= stageRWeights[i];
   }
-  
+
   // Compute kernel supports for sampling density function
   for(int i=0; i<N; i++){
     angleMean[i] = particles[i].angle;
@@ -402,7 +402,7 @@ void VectorLocalization2D::computeParticleWeights(vector2f deltaLoc, float delta
     locMean[i] = particles[i].loc;
     locStdDev[i].x = 1.0/sq(max( (deltaLoc.rotate(particles[i].angle).x)*motionParams.Alpha3, currentLocStdDev.x));
     locStdDev[i].y = 1.0/sq(max( (deltaLoc.rotate(particles[i].angle).y)*motionParams.Alpha3, currentLocStdDev.y));
-    
+
     angleMean[N+i] = particlesRefined[i].angle;
     angleStdDev[N+i] = 1.0/sq( max( float(fabs(deltaAngle))*motionParams.Alpha1 + deltaTranslation*motionParams.Alpha2 , currentAngleStdDev) );
     locMean[N+i] = particlesRefined[i].loc;
@@ -422,7 +422,7 @@ void VectorLocalization2D::computeParticleWeights(vector2f deltaLoc, float delta
     p1.weight = p1.weight/w1;
     p2.weight = p2.weight/w2;
   }
-  
+
   if(debug){
     printf("Final weights:\n");
     for(int i=0; i<N; i++){
@@ -435,15 +435,15 @@ void VectorLocalization2D::updateLidar(const LidarParams &lidarParams, const Mot
 {
   static const bool debug = false;
   static const bool usePermissibility = true;
-  
+
   double tStart = GetTimeSec();
-  
+
   // Transform laserpoints to robot frame
   vector< Vector2f > laserPoints(lidarParams.numRays);
   for(int i=0; i<lidarParams.numRays; i++){
     laserPoints[i] = lidarParams.laserToBaseTrans + lidarParams.laserToBaseRot*lidarParams.scanHeadings[i]*lidarParams.laserScan[i];
   }
-  
+
   //Compute the sampling density
   float sqDensityKernelSize = sq(lidarParams.kernelSize);
   float totalDensity = 0.0;
@@ -468,7 +468,7 @@ void VectorLocalization2D::updateLidar(const LidarParams &lidarParams, const Mot
   for(int i=0; i<N; i++){
     samplingDensity[i] /= totalDensity;
   }
-  
+
   //Compute importance weights = observation x motion / samplingDensity
   if(debug) printf("\nParticle weights:\n");
   for(int i=0; i<N; i++){
@@ -478,7 +478,7 @@ void VectorLocalization2D::updateLidar(const LidarParams &lidarParams, const Mot
     p.weight = w1*w2/samplingDensity[i];
     if(debug) printf("%2d: %f , %f , %f\n",i,w1,w2,p.weight);
   }
-  
+
   updateTime = GetTimeSec() - tStart;
 }
 
@@ -486,9 +486,9 @@ void VectorLocalization2D::updatePointCloud(vector< vector2f >& pointCloud, vect
 {
   static const bool debug = false;
   static const bool usePermissibility = true;
-  
+
   double tStart = GetTimeSec();
-  
+
   //Compute the sampling density
   float sqDensityKernelSize = sq(pointCloudParams.kernelSize);
   float totalDensity = 0.0;
@@ -513,7 +513,7 @@ void VectorLocalization2D::updatePointCloud(vector< vector2f >& pointCloud, vect
   for(int i=0; i<N; i++){
     samplingDensity[i] /= totalDensity;
   }
-  
+
   //Compute importance weights = observation x motion / samplingDensity
   if(debug) printf("\nParticle weights:\n");
   for(int i=0; i<N; i++){
@@ -523,19 +523,19 @@ void VectorLocalization2D::updatePointCloud(vector< vector2f >& pointCloud, vect
     p.weight = w1*w2/samplingDensity[i];
     if(debug) printf("%2d: %f , %f , %f\n",i,w1,w2,p.weight);
   }
-  
+
   updateTime = GetTimeSec() - tStart;
 }
 
 void VectorLocalization2D::predictParticle(Particle2D& p, float dx, float dy, float dtheta, const MotionModelParams &motionParams)
 {
   static const bool debug = false;
-  
+
   if(debug) printf("predict before: %7.2f,%7.2f %6.2f\u00b0 ",p.loc.x,p.loc.y,DEG(p.angle));
   //Motion model
   vector2f delta(dx,dy);
   float d_trans = delta.length();
-  
+
   //Predict rotation
   dtheta += randn(motionParams.Alpha1*dtheta,0.0f)+randn(motionParams.Alpha2*d_trans,0.0f);
   p.angle = angle_mod(p.angle+dtheta);
@@ -552,17 +552,17 @@ void VectorLocalization2D::predictParticle(Particle2D& p, float dx, float dy, fl
 inline Vector2f VectorLocalization2D::attractorFunction(line2f l, Vector2f p, float attractorRange, float margin)
 {
   static const bool debug = false;
-  
+
   Vector2f attraction(0.0,0.0), dir(V2COMP(l.Dir())), p0(V2COMP(l.P0())), p1(V2COMP(l.P1()));
-  
+
   float location = (p-p0).dot(dir);
-  
+
   if(location<-margin || location>l.Length()+margin){
     return attraction;
   }
-  
+
   attraction = (p-p0) - dir*location ;
-  
+
   float d = attraction.norm();
   /*
   if(d>0.5*attractorRange){
@@ -601,13 +601,13 @@ void VectorLocalization2D::getPointCloudGradient(vector2f loc, float angle, vect
   FunctionTimer *ft;
   if(EnableProfiling)
     ft = new FunctionTimer(__FUNCTION__);
-  
+
   float numTotalPoints = pointCloud.size();
-  
+
   if(EnableProfiling) ft->Lap(__LINE__);
   //vector<int> lineCorrespondences;
   //vector<line2f> lines;
-  
+
   /*
   float minRange = pointCloudParams.minRange;
   float maxRange = pointCloudParams.maxRange;
@@ -621,40 +621,40 @@ void VectorLocalization2D::getPointCloudGradient(vector2f loc, float angle, vect
   }
   */
   if(EnableProfiling) ft->Lap(__LINE__);
-  
+
   float numPoints = 0;
-  
+
   float cosAngle;
   int noCorrespondences = 0;
   logWeight = 0.0;
-  
+
   int numObservedPoints = int(pointCloud.size());
   pointCloudEval.numObservedPoints = numObservedPoints;
-  
+
   //Construct gradients per point in point cloud
   gradients2.resize(numObservedPoints);
   points2.resize(numObservedPoints);
   int numPointsInt = 0;
-  
+
   Vector2f curPoint, locE(V2COMP(loc)), attraction, lineNorm, rotatedNormal;
   Matrix2f rotMat1;
   rotMat1 = Rotation2Df(angle);
-  
+
   for(int i=0; i<numObservedPoints; i++){
     curPoint = rotMat1*Vector2f(V2COMP(pointCloud[i])) + locE;
     rotatedNormal = rotMat1*Vector2f(V2COMP(pointNormals[i]));
     attraction = Vector2f(0,0);
-    
+
     if(lineCorrespondences[i]>=0 && lineCorrespondences[i]<lines.size()){
       lineNorm = Vector2f(V2COMP(lines[lineCorrespondences[i]].Perp()));
       cosAngle = fabs(lineNorm.dot(rotatedNormal));
-      
+
       //Attraction only for valid correspondences
       if(cosAngle > pointCloudParams.minCosAngleError){
         attraction = attractorFunction(lines[lineCorrespondences[i]], curPoint,pointCloudParams.attractorRange, pointCloudParams.correspondenceMargin);
         //Add the point and attraction (only if non-zero)
         //logWeight += -min(attraction.squaredNorm()/pointCloudParams.stdDev, -pointCloudParams.logShortHitProb)*pointCloudParams.corelationFactor;
-        
+
         gradients2[numPointsInt] = attraction;
         points2[numPointsInt] = curPoint;
         numPointsInt++;
@@ -667,15 +667,15 @@ void VectorLocalization2D::getPointCloudGradient(vector2f loc, float angle, vect
   gradients2.resize(numPointsInt);
   numPoints = float(numPointsInt);
   pointCloudEval.numCorrespondences = int(points2.size());
-  
+
   if(debug) printf("No correspondences: %d/%d \n",noCorrespondences,int(pointCloud.size()));
-  
+
   if(numPoints<pointCloudParams.minPoints){
     locGrad.zero();
     angleGrad = 0.0;
     return;
   }
-  
+
   //Estimate translation and rotation
   Vector2f locGradE(0,0);
   Vector2f heading(0,0), curHeading, r;
@@ -686,7 +686,7 @@ void VectorLocalization2D::getPointCloudGradient(vector2f loc, float angle, vect
     pointCloudEval.meanSqError += gradients2[i].squaredNorm();
     if(r.squaredNorm()<sq(0.001))
       continue;
-    
+
     locGradE += gradients2[i];
     headingAngle = eigenCross(r,gradients2[i]);
     curHeading = Vector2f(cos(headingAngle),sin(headingAngle));
@@ -696,31 +696,31 @@ void VectorLocalization2D::getPointCloudGradient(vector2f loc, float angle, vect
   locGrad.set(locGradE.x(),locGradE.y());
   heading = heading/numPoints;
   pointCloudEval.meanSqError = pointCloudEval.meanSqError/numPoints;
-  
+
   angleGrad = bound(atan2(heading.y(),heading.x()),-pointCloudParams.maxAngleGradient,pointCloudParams.maxAngleGradient);
-  
+
   locGrad = locGrad.bound(pointCloudParams.maxLocGradient);
   if(debug) printf("LocGrad: %6.2f %6.2f AngleGrad:%6.1f\u00b0\n",V2COMP(locGrad), DEG(angleGrad));
-    
+
   if(EnableProfiling) delete ft;
 }
 
 void VectorLocalization2D::getLidarGradient(vector2f loc, float angle, vector2f& locGrad, float& angleGrad, float& logWeight, VectorLocalization2D::LidarParams lidarParams, const vector<Vector2f>& laserPoints, const vector<int> & lineCorrespondences, const vector<line2f> &lines)
 {
   static const bool EnableProfiling = false;
-  
+
   FunctionTimer *ft;
   if(EnableProfiling)
     ft = new FunctionTimer(__PRETTY_FUNCTION__);
-  
+
   float logShortHitProb = lidarParams.logShortHitProb;
   Matrix2f robotAngle;
   robotAngle = Rotation2Df(angle);
   Vector2f laserLocE = Vector2f(V2COMP(loc)) + robotAngle*(lidarParams.laserToBaseTrans);
   vector2f laserLoc(laserLocE.x(), laserLocE.y());
-  
+
   if(EnableProfiling) ft->Lap(__LINE__);
-  
+
   /*
   if(UseAnalyticRender){
     lineCorrespondences = currentMap->getRayToLineCorrespondences(laserLoc, angle, lidarParams.angleResolution, lidarParams.numRays, lidarParams.minRange, lidarParams.maxRange, true, &lines);
@@ -729,7 +729,7 @@ void VectorLocalization2D::getLidarGradient(vector2f loc, float angle, vector2f&
   }
   */
   if(EnableProfiling) ft->Lap(__LINE__);
-  
+
   points.clear();
   gradients.clear();
   static const bool debug = false;
@@ -746,20 +746,20 @@ void VectorLocalization2D::getLidarGradient(vector2f loc, float angle, vector2f&
   curAngle = angle - midScan*lidarParams.angleResolution;
   //Construct gradients per point in point cloud
   if(EnableProfiling) ft->Lap(__LINE__);
-  
+
   Matrix2f robotAngle2;
   robotAngle2 = Rotation2Df(angle+lidarParams.angleResolution);
   Vector2f scanPoint, scanPoint2, scanDir, lineDir, attraction;
-  
+
   //TODO: Speed up this section!!
   //===========================================================================
   laserEval.numObservedPoints = 0;
   for(int i=0; i<lidarParams.numRays-1; i++, curAngle+=lidarParams.angleResolution){
     if(scanRays[i]<minRange || scanRays[i]>maxRange)
       continue;
-    laserEval.numObservedPoints++;  
+    laserEval.numObservedPoints++;
     scanPoint = laserLocE + robotAngle*laserPoints[i];
-    
+
     if(lineCorrespondences[i]>=0){
       scanPoint2 = laserLocE + robotAngle2*laserPoints[i+1];
       scanDir = (scanPoint2-scanPoint).normalized();
@@ -779,23 +779,23 @@ void VectorLocalization2D::getLidarGradient(vector2f loc, float angle, vector2f&
     }else{
       noCorrespondences++;
     }
-    
-  }  
+
+  }
   numPoints = float(points.size());
   laserEval.numCorrespondences = int(points.size());
-  
+
   //if(debug) printf("No correspondences: %d/%d numPoints:%d\n",noCorrespondences,lidarParams.numRays,int(numPoints));
   //===========================================================================
-  
+
   if(EnableProfiling) ft->Lap(__LINE__);
-  
+
   if(numPoints<lidarParams.minPoints){
     locGrad.zero();
     angleGrad = 0.0;
     if(EnableProfiling) delete ft;
     return;
   }
-  
+
   //Estimate translation and rotation
   locGrad.zero();
   heading = Vector2f(0,0);
@@ -815,9 +815,9 @@ void VectorLocalization2D::getLidarGradient(vector2f loc, float angle, vector2f&
   locGrad.set(locGradE.x(),locGradE.y());
   heading /= numPoints;
   laserEval.meanSqError /= numPoints;
-  
+
   if(EnableProfiling) ft->Lap(__LINE__);
-    
+
   locGrad = locGrad.bound(lidarParams.maxLocGradient);
   angleGrad = bound(atan2(heading.y(),heading.x()),-lidarParams.maxAngleGradient,lidarParams.maxAngleGradient);
   if(EnableProfiling) delete ft;
@@ -827,17 +827,17 @@ void VectorLocalization2D::getLidarGradient(vector2f loc, float angle, vector2f&
 void VectorLocalization2D::refineLocationLidar(vector2f& loc, float& angle, float& initialWeight, float& finalWeight, const LidarParams &lidarParams, const vector<Vector2f> &laserPoints)
 {
   static const bool debug = false;
-  
+
   //Do gradient descent for this particle
   vector2f locGrad(0.0,0.0);
   float angleGrad = 0.0;
   bool beingRefined = true;
   float weight;
-  
+
   if(debug) printf("before: %.4f,%.4f %.2f\u00b0\n",V2COMP(loc),DEG(angle));
-  
+
   Matrix2f robotAngle;
-  robotAngle = Rotation2Df(angle);  
+  robotAngle = Rotation2Df(angle);
   Vector2f laserLocE = Vector2f(V2COMP(loc)) + robotAngle*(lidarParams.laserToBaseTrans);
   vector2f laserLoc(laserLocE.x(), laserLocE.y());
   vector<line2f> lines;
@@ -846,7 +846,7 @@ void VectorLocalization2D::refineLocationLidar(vector2f& loc, float& angle, floa
   }else{
     lineCorrespondences = currentMap->getRayToLineCorrespondences(laserLoc, angle, lidarParams.angleResolution, lidarParams.numRays, lidarParams.minRange, lidarParams.maxRange);
   }
-  
+
   for(int i=0; beingRefined && i<lidarParams.numSteps; i++){
     getLidarGradient(loc,angle,locGrad,angleGrad,weight,lidarParams, laserPoints, lineCorrespondences, lines);
     if(i==0) initialWeight = exp(weight);
@@ -854,7 +854,7 @@ void VectorLocalization2D::refineLocationLidar(vector2f& loc, float& angle, floa
     angle -= lidarParams.etaAngle*angleGrad;
     beingRefined = fabs(angleGrad)>lidarParams.minRefineFraction*lidarParams.maxAngleGradient && locGrad.sqlength()>sq(lidarParams.minRefineFraction*lidarParams.maxLocGradient);
   }
-  
+
   if(debug) printf("after: %.4f,%.4f %.2f\u00b0\n",V2COMP(loc),DEG(angle));
   finalWeight = exp(weight);
 }
@@ -863,13 +863,13 @@ void VectorLocalization2D::refineLocationPointCloud(vector2f& loc, float& angle,
 {
   static const bool debug = false;
   //FunctionTimer ft(__PRETTY_FUNCTION__);
-  
+
   //Do gradient descent for this particle
   vector2f locGrad(0.0,0.0);
   float angleGrad = 0.0;
   bool beingRefined = true;
-  
-  
+
+
   float a0 = angle-0.5*pointCloudParams.fieldOfView;
   float a1 = angle+0.5*pointCloudParams.fieldOfView;
   vector<line2f> lines;
@@ -879,7 +879,7 @@ void VectorLocalization2D::refineLocationPointCloud(vector2f& loc, float& angle,
     lineCorrespondences = currentMap->getRayToLineCorrespondences(loc, angle, a0, a1, pointCloud, pointCloudParams.minRange, pointCloudParams.maxRange);
     lines = currentMap->lines;
   }
-  
+
   vector2f locPrev = loc;
   float anglePrev = angle;
   float weight;
@@ -903,13 +903,13 @@ void VectorLocalization2D::refineLidar(const LidarParams &lidarParams)
   laserEval.stage0Weights = 0.0;
   laserEval.stageRWeights = 0.0;
   laserEval.lastRunTime = GetTimeSec();
-  
+
   // Transform laserpoints to robot frame
   vector< Vector2f > laserPoints(lidarParams.numRays);
   for(int i=0; i<lidarParams.numRays; i++){
     laserPoints[i] = lidarParams.laserToBaseTrans + lidarParams.laserToBaseRot*lidarParams.scanHeadings[i]*lidarParams.laserScan[i];
   }
-  
+
   particlesRefined = particles;
   if(lidarParams.numSteps>0){
     for(int i=0; i<numParticles; i++){
@@ -927,11 +927,11 @@ void VectorLocalization2D::reducePointCloud(const std::vector< vector2f >& point
 {
   static const bool debug = false;
   static const float eps = -RAD(0.001);
-  
+
   vector<pair<float, int> > angles;
   size_t N = pointCloud.size();
   pair<float,int> valuePair;
-  
+
   for(unsigned int i=0; i<N; i++){
     valuePair.first = pointCloud[i].angle();
     valuePair.second = i;
@@ -939,8 +939,8 @@ void VectorLocalization2D::reducePointCloud(const std::vector< vector2f >& point
   }
   //N = min(angles.size(),N);
   sort<vector<pair<float, int> >::iterator >(angles.begin(), angles.end());
-  
-  
+
+
   reducedPointCloud.resize(N);
   reducedPointNormals.resize(N);
   int j=0;
@@ -950,7 +950,7 @@ void VectorLocalization2D::reducePointCloud(const std::vector< vector2f >& point
     reducedPointNormals[j] = pointNormals[angles[i].second];
     j++;
     lastAngle = angles[i].first;
-    
+
     for(i++;i<N && angles[i].first<=lastAngle+eps;){
       i++;
     }
@@ -958,8 +958,8 @@ void VectorLocalization2D::reducePointCloud(const std::vector< vector2f >& point
   N = j;
   reducedPointCloud.resize(N);
   reducedPointNormals.resize(N);
-  
-  
+
+
   if(debug){
     printf("\n");
     for(unsigned int i=0; i<N; i++){
@@ -976,12 +976,12 @@ void VectorLocalization2D::refinePointCloud(const vector<vector2f> &pointCloud, 
   pointCloudEval.stage0Weights = 0.0;
   pointCloudEval.stageRWeights = 0.0;
   pointCloudEval.lastRunTime = GetTimeSec();
-  
+
   /*
   vector< vector2f > reducedPointCloud, reducedPointNormals;
   reducePointCloud(pointCloud, pointNormals, reducedPointCloud, reducedPointNormals);
   */
-  
+
   particlesRefined = particles;
   if(pointCloudParams.numSteps>0){
     for(int i=0; i<numParticles; i++){
@@ -1008,7 +1008,7 @@ void VectorLocalization2D::computeLocation(vector2f& loc, float& angle)
   }
   currentAngle = avgHeading.angle();
   currentLocation = currentLocation/float(numParticles);
-  
+
   currentLocStdDev.zero();
   currentAngleStdDev = 0.0;
   float xStdDev=0.0, yStdDev=0.0;
@@ -1047,13 +1047,13 @@ void VectorLocalization2D::resample(Resample type)
 }
 
 void VectorLocalization2D::lowVarianceResample()
-{ 
+{
   vector<Particle2D> newParticles;
   newParticles.resize(numParticles);
   float totalWeight = 0.0;
   float newWeight = 1.0/float(numParticles);
   int numRefinedParticles = (int) particlesRefined.size();
-  
+
   refinedImportanceWeights = unrefinedImportanceWeights = 0.0;
   for(int i=0; i<numRefinedParticles; i++){
     //Get rid of particles with undefined weights
@@ -1065,7 +1065,7 @@ void VectorLocalization2D::lowVarianceResample()
     else
       unrefinedImportanceWeights += particlesRefined[i].weight;
   }
-  
+
   if(totalWeight<FLT_MIN){
     //TerminalWarning("Particles have zero total weight!");
     for(int i=0; i<numParticles; i++){
@@ -1074,10 +1074,10 @@ void VectorLocalization2D::lowVarianceResample()
     return;
     //exit(0);
   }
-  
+
   float weightIncrement = totalWeight/float(numParticles);
   if(weightIncrement<FLT_MIN) TerminalWarning("Particle weights less than float precision");
-  
+
   numRefinedParticlesSampled = numUnrefinedParticlesSampled = 0;
   float x = frand(0.0f,totalWeight);
   int j=0;
@@ -1091,7 +1091,7 @@ void VectorLocalization2D::lowVarianceResample()
       numRefinedParticlesSampled++;
     else
       numUnrefinedParticlesSampled++;
-    
+
     newParticles[i] = particlesRefined[j];
     newParticles[i].weight = newWeight;
     if(particlesRefined[i].weight < FLT_MIN){
@@ -1104,7 +1104,7 @@ void VectorLocalization2D::lowVarianceResample()
     }
     x += weightIncrement;
   }
-  
+
   particles = newParticles;
 }
 
@@ -1116,7 +1116,7 @@ void VectorLocalization2D::naiveResample()
   float totalWeight = 0.0;
   float newWeight = 1.0/numParticles;
   int numRefinedParticles = (int) particlesRefined.size();
-  
+
   refinedImportanceWeights = unrefinedImportanceWeights = 0.0;
   int numInfs=0, numNans=0, numNegs=0;
   for(int i=0; i<numRefinedParticles; i++){
@@ -1142,7 +1142,7 @@ void VectorLocalization2D::naiveResample()
     return;
     //exit(0);
   }
-  
+
   numRefinedParticlesSampled = numUnrefinedParticlesSampled = 0;
   for(int i=0; i<numParticles; i++){
     float x = frand(0.0f,totalWeight);
@@ -1164,7 +1164,7 @@ void VectorLocalization2D::naiveResample()
 }
 
 void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &lines_p1y, vector<float> &lines_p2x, vector<float> &lines_p2y, vector<uint32_t> &lines_color,
-                                     vector<float> &points_x, vector<float> &points_y, vector<uint32_t> &points_color, 
+                                     vector<float> &points_x, vector<float> &points_y, vector<uint32_t> &points_color,
                                        vector<float> &circles_x, vector<float> &circles_y, vector<uint32_t> &circles_color, float scale)
 {
   static const bool debug = false;
@@ -1173,7 +1173,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
   static const bool drawKinectPoints = true;
   static const bool drawCorrections = true;
   static const bool drawSceneRender = false;
-  
+
   static const float GradientsScale = 1.0;
   static const int ParticleCloudColor = 0xF77274;
   static const int LidarPointColor = 0xF0761F;
@@ -1183,7 +1183,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
   static const int LineCorrespondenceColor = 0x93FA70;
   static const int LineExtentColor = 0xFFD659;
   static const int DebugColour = 0xFF0000;
-  
+
   for(int i=0; i<debugLines.size(); i++){
     lines_p1x.push_back(scale*debugLines[i].P0().x);
     lines_p1y.push_back(scale*debugLines[i].P0().y);
@@ -1192,7 +1192,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
     lines_color.push_back(DebugColour);
   }
   debugLines.clear();
-  
+
   if(drawCorrections){
     vector2f p2 = locCorrectionP1 + 20.0*(locCorrectionP1 - locCorrectionP0);
     lines_p1x.push_back(scale*locCorrectionP0.x);
@@ -1201,14 +1201,14 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
     lines_p2y.push_back(scale*p2.y);
     lines_color.push_back(0x1BE042);
   }
-  
+
   if(drawParticles){
     //Draw all (unrefined) particles
     for(int i=0; i<particles.size(); i++){
       circles_x.push_back(scale*particles[i].loc.x);
       circles_y.push_back(scale*particles[i].loc.y);
       circles_color.push_back(ParticleCloudColor);
-      
+
       vector2f h;
       h.heading(particles[i].angle);
       vector2f p = particles[i].loc + 0.3*h;
@@ -1219,7 +1219,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       lines_color.push_back(ParticleCloudColor);
     }
   }
-  
+
   if(drawSceneRender){
     vector2f loc;
     float angle;
@@ -1230,7 +1230,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       locVisibilityList = *currentMap->getVisibilityList(loc.x, loc.y);
     else
       locVisibilityList = currentMap->getSceneLines(loc, 6.5);
-    
+
     for(unsigned int i=0; i<locVisibilityList.size(); i++){
       lines_p1x.push_back(scale*currentMap->lines[locVisibilityList[i]].P0().x);
       lines_p1y.push_back(scale*currentMap->lines[locVisibilityList[i]].P0().y);
@@ -1238,7 +1238,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       lines_p2y.push_back(scale*currentMap->lines[locVisibilityList[i]].P1().y);
       lines_color.push_back(0x00DE07);
     }
-    
+
     vector<vector2f> rays;
     vector2f ray;
     bool duplicate;
@@ -1248,7 +1248,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       lines_p2x.push_back(scale*lines[i].P1().x);
       lines_p2y.push_back(scale*lines[i].P1().y);
       lines_color.push_back(DebugColour);
-      
+
       duplicate = false;
       ray = lines[i].P0()-loc;
       for(int j=0; j<rays.size()&&!duplicate; j++){
@@ -1259,7 +1259,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       }
       if(!duplicate)
         rays.push_back(ray);
-      
+
       duplicate = false;
       ray = lines[i].P1()-loc;
       for(int j=0; j<rays.size()&&!duplicate; j++){
@@ -1271,7 +1271,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       if(!duplicate)
         rays.push_back(ray);
     }
-    
+
     for(int i=0; i<rays.size(); i++){
       vector2f p0 = loc;
       vector2f p1 = rays[i]+loc;
@@ -1281,9 +1281,9 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       lines_p2y.push_back(scale*p1.y);
       lines_color.push_back(LineExtentColor);
     }
-    
+
   }
-  
+
   if(drawLidarPoints){
     // Draw all LIDAR points considered for gradient descent, as well as their gradients
     for(int i=0; i<points.size(); i++){
@@ -1298,7 +1298,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       lines_color.push_back(LidarGradientColor);
     }
   }
-  
+
   if(drawKinectPoints){
     // Draw all point cloud points considered for gradient descent, as well as their gradients
     for(int i=0; i<points2.size(); i++){
@@ -1313,7 +1313,7 @@ void VectorLocalization2D::drawDisplay(vector<float> &lines_p1x, vector<float> &
       lines_color.push_back(CloudGradientColor);
     }
   }
-  
+
 }
 
 void VectorLocalization2D::saveProfilingStats(FILE* f)

--- a/src/cgr/vectorparticlefilter.cpp
+++ b/src/cgr/vectorparticlefilter.cpp
@@ -1175,6 +1175,8 @@ void VectorLocalization2D::kldResample(KLDParams kldParams)
       newParticles[i].angle += deltaAngle;
     }
     x += weightIncrement;
+    if (x > totalWeight) x -= totalWeight;
+    if (f > totalWeight) f -= totalWeight;
 
     // now that we have picked a new particle, we need to know if it is in a new bin.
     vector<double> current_bin;

--- a/src/cgr/vectorparticlefilter.h
+++ b/src/cgr/vectorparticlefilter.h
@@ -56,11 +56,11 @@ Particle filter for vector localization
 **/
 
 class VectorLocalization2D{
-  
+
 public:
   typedef struct {
     double tStamp;
-    
+
     //Parameters
     /// Alpha1 = Error in angle per delta in angle
     float Alpha1;
@@ -68,10 +68,10 @@ public:
     float Alpha2;
     /// Alpha3 = Error in translation per delta in translation
     float Alpha3;
-    
+
     float kernelSize;
   } MotionModelParams;
-  
+
   class LidarParams{
     public:
     float* laserScan;
@@ -85,7 +85,7 @@ public:
     Vector2f laserToBaseTrans;
     Matrix2f laserToBaseRot;
     vector<Vector2f> scanHeadings;
-    
+
     int numSteps;
     float etaAngle;
     float etaLoc;
@@ -95,27 +95,27 @@ public:
     float minCosAngleError;
     float correspondenceMargin;
     float minRefineFraction;
-    
+
     float logObstacleProb; //Probability of an obstacle
     float logShortHitProb;
     float logOutOfRangeProb;
     float lidarStdDev;
     float correlationFactor;
-    
+
     float kernelSize;
-    
+
     void initialize();
   };
-  
+
   class PointCloudParams{
-    public: 
+    public:
     double tStamp;
     float minRange;
     float maxRange;
     float fieldOfView;
     vector<vector2f> pointCloud;
     vector<vector2f> pointNormals;
-    
+
     //Tunable parameters, MUST be set!
     float logObstacleProb; //Probability of an obstacle
     float logShortHitProb;
@@ -123,7 +123,7 @@ public:
     float attractorRange;
     float stdDev;
     float corelationFactor;
-    
+
     int numSteps;
     int minPoints;
     float etaAngle;
@@ -133,11 +133,11 @@ public:
     float minCosAngleError;
     float correspondenceMargin;
     float minRefineFraction;
-    
+
     float kernelSize;
   };
-  
-  
+
+
   typedef struct {
     double lastRunTime;
     double runTime;
@@ -147,13 +147,13 @@ public:
     float stageRWeights;
     float meanSqError;
   } EvalValues;
-  
+
   enum Resample{
     NaiveResampling,
     LowVarianceResampling,
     SensorResettingResampling,
   };
-  
+
 protected:
   //Current state
   VectorMap* currentMap;
@@ -167,10 +167,10 @@ protected:
   vector<float> samplingDensity;
   vector2f lastDistanceMoved;
   float lastAngleTurned;
-  
+
   string mapsFolder;
   vector<VectorMap> maps;
-  
+
   //These are class-wide only so that they can be accessed for debugging purposes
   vector<float> stage0Weights;
   vector<float> stageRWeights;
@@ -181,7 +181,7 @@ protected:
   vector<line2f> debugLines;
   vector<int> lineCorrespondences;
   vector2f locCorrectionP0, locCorrectionP1;
-  
+
   //Statistics of performance
   int numUnrefinedParticlesSampled;
   int numRefinedParticlesSampled;
@@ -191,11 +191,11 @@ protected:
   double updateTime;
   EvalValues pointCloudEval;
   EvalValues laserEval;
-    
+
 public:
   VectorLocalization2D(const char* _mapsFolder);
   VectorLocalization2D(int _numParticles);
-  
+
   /// Sets Particle Filter LIDAR parameters
   void setParams(MotionModelParams _predictParams, LidarParams _lidarUpdateParams);
   /// Loads All the floor maps listed in atlas.txt
@@ -214,17 +214,17 @@ public:
   void updatePointCloud(vector< vector2f >& pointCloud, vector< vector2f >& pointNormals, const VectorLocalization2D::MotionModelParams& motionParams, const VectorLocalization2D::PointCloudParams& pointCloudParams);
   /// Resample distribution
   void resample(Resample type = LowVarianceResampling);
-  
+
   /// Predict particle motion by sampling from the motion model
   void predictParticle(Particle2D& p, float dx, float dy, float dtheta, const VectorLocalization2D::MotionModelParams& motionParams);
   /// Refine a single location hypothesis based on a LIDAR observation
   void refineLocationLidar(vector2f& loc, float& angle, float& initialWeight, float& finalWeight, const VectorLocalization2D::LidarParams& lidarParams, const std::vector< Vector2f >& laserPoints);
   /// Refine a single location hypothesis based on a Point Cloud observation
   void refineLocationPointCloud(vector2f& loc, float& angle, float& initialWeight, float& finalWeight, const vector< vector2f >& pointCloud, const vector< vector2f >& pointNormals, const VectorLocalization2D::PointCloudParams& pointCloudParams);
-  
+
   void computeParticleWeights(vector2f deltaLoc, float deltaAngle, vector2f minLocStdDev, float minAngleStdDev, const VectorLocalization2D::MotionModelParams& motionParams);
-  
-  /// Attractor function used for refining location hypotheses 
+
+  /// Attractor function used for refining location hypotheses
   inline Vector2f attractorFunction(line2f l, Vector2f p, float attractorRange, float margin = 0);
   /// Observation function for a single ray
   inline Vector2f observationFunction(line2f l, Vector2f p);
@@ -260,7 +260,7 @@ public:
   void saveProfilingStats(FILE* f);
   /// Compile lists of drawing primitives that can be visualized for debugging purposes
   void drawDisplay(vector<float> &lines_p1x, vector<float> &lines_p1y, vector<float> &lines_p2x, vector<float> &lines_p2y, vector<uint32_t> &lines_color,
-                   vector<float> &points_x, vector<float> &points_y, vector<uint32_t> &points_color, 
+                   vector<float> &points_x, vector<float> &points_y, vector<uint32_t> &points_color,
                    vector<float> &circles_x, vector<float> &circles_y, vector<uint32_t> &circles_color, float scale=1.0);
   /// Return evaluation values
   void getEvalValues(EvalValues &_laserEval, EvalValues &_pointCloudEval);
@@ -273,4 +273,3 @@ public:
 };
 
 #endif //VECTORPARTICLEFILTER_H
-

--- a/src/cgr/vectorparticlefilter.h
+++ b/src/cgr/vectorparticlefilter.h
@@ -137,6 +137,14 @@ public:
     float kernelSize;
   };
 
+  typedef struct {
+    int minParticles;
+    int maxParticles;
+    double bin_size;
+    double angular_bin_size;
+    double error;
+    double z_score;
+  } KLDParams;
 
   typedef struct {
     double lastRunTime;
@@ -248,6 +256,8 @@ public:
   void lowVarianceResample();
   /// Resample particles using naive resampling
   void naiveResample();
+  /// Resample particles until we have enough to maintain KL Distance error
+  void kldResample(VectorLocalization2D::KLDParams kldParams);
   /// Compute the maximum likelihood location based on particle spread
   void computeLocation(vector2f &loc, float &angle);
   /// Returns the current map name


### PR DESCRIPTION
This adds a new resampling method the corrective gradient refinement particle filter for robot localization.
Instead of using the resample() method in lidarCallback, we use the kldResample(params) method. The parameters can be set in the localization config file. Parameters to set are the min and max number of particles desired, the bin size and angular bin size to determine resolution of the discretization. Finally, there is the desired error and z_score. The error is the max KL distance we want to allow, and the z_score corresponds to the probability we want to ensure that we are in fact below that error. The default of 2.5 corresponds to a 99% probability (the 99th percentile of a normal distribution with mean zero and var 1). 

The kldResample(params) method combines the lowVarianceResample with the idea of KLD from [D.Fox ('03)](https://rse-lab.cs.washington.edu/postscripts/adaptive-ijrr-2003.pdf). The effect of this is that we can increase or decrease as needed the number of particles. This can be useful for example for global localization, where we need an enormous number of particles in the beginning to find out where we are, but then we only need a few once we have found out. It can also be useful if the robot enters an area with sparse observations, for example a large empty room, and the particles spread out.
